### PR TITLE
Adding Debug mode and renaming skip dir options

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -3,14 +3,16 @@ package cmd
 import (
 	"fmt"
 
+	log "github.com/sirupsen/logrus"
+
 	"github.com/mmiranda/markdown-index/markdown"
 	"github.com/spf13/cobra"
 	goVersion "go.hein.dev/go-version"
 )
 
 var (
-	directory, output, skipDirectory, useHeading string
-	// maxDepth          int
+	directory, output, skip, useHeading string
+	debug                               bool
 )
 
 // rootCmd represents the base command when called without any subcommands
@@ -21,6 +23,11 @@ var rootCmd = &cobra.Command{
 reads all markdown files recursively and generate for you
 a index file with the summary of each file found.`,
 	Run: func(cmd *cobra.Command, args []string) {
+
+		if debug {
+			markdown.LogLevel = log.DebugLevel
+		}
+
 		markdown.Execute(output, directory)
 	},
 }
@@ -55,8 +62,9 @@ func init() {
 
 	rootCmd.PersistentFlags().StringVar(&directory, "directory", ".", "Directory to search markdown files recursively")
 	rootCmd.PersistentFlags().StringVar(&output, "output", "markdown-index.md", "Final markdown file to be created")
-	rootCmd.PersistentFlags().StringVar(&skipDirectory, "skipDirectory", "", "Skip directory in the recursive walk")
+	rootCmd.PersistentFlags().StringVar(&skip, "skip", "s", "Skip directory in the recursive walk")
 	rootCmd.PersistentFlags().StringVar(&useHeading, "heading", "", "Use this Heading inside the markdown file as summary of the file")
+	rootCmd.PersistentFlags().BoolVarP(&debug, "debug", "d", false, "Enable Debug Mode.")
 	// rootCmd.PersistentFlags().StringVar(&output, "maxDepth", "5", "Maximum depth level to look for files")
 
 }

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,8 @@ go 1.17
 
 require github.com/yuin/goldmark v1.4.1
 
+require golang.org/x/sys v0.0.0-20210510120138-977fb7262007 // indirect
+
 require (
 	github.com/Kunde21/markdownfmt/v2 v2.1.0
 	github.com/abhinav/goldmark-toc v0.2.0
@@ -29,4 +31,7 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 )
 
-require sigs.k8s.io/yaml v1.1.0 // indirect
+require (
+	github.com/sirupsen/logrus v1.8.1
+	sigs.k8s.io/yaml v1.1.0 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -263,6 +263,8 @@ github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
+github.com/sirupsen/logrus v1.8.1 h1:dJKuHgqk1NNQlqoA6BTlM1Wf9DOH3NBjQyu0h9+AZZE=
+github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
@@ -452,6 +454,7 @@ golang.org/x/sys v0.0.0-20190726091711-fc99dfbffb4e/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190812172437-4e8604ab3aff/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191001151750-bb3f8db39f24/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191005200804-aed5e4c7ecf9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191204072324-ce4227a45e2e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191228213918-04cbcbbfeed8/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200113162924-86b910548bc1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -479,6 +482,7 @@ golang.org/x/sys v0.0.0-20210315160823-c6e025ad8005/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210320140829-1e4c9ba3b0c4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210403161142-5e06dd20ab57/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210510120138-977fb7262007 h1:gG67DSER+11cZvqIMb8S8bt0vZtiN6xWYARwirrOSfE=
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/markdown/markdown.go
+++ b/markdown/markdown.go
@@ -4,13 +4,15 @@ import (
 	"bufio"
 	"bytes"
 	"io/ioutil"
-	"log"
+
+	// "log"
 	"os"
 	"path/filepath"
 	"strings"
 
 	mdrender "github.com/Kunde21/markdownfmt/v2/markdown"
 	toc "github.com/abhinav/goldmark-toc"
+	log "github.com/sirupsen/logrus"
 	"github.com/yuin/goldmark"
 	meta "github.com/yuin/goldmark-meta"
 	"github.com/yuin/goldmark/ast"
@@ -21,6 +23,9 @@ import (
 var (
 	ignoreDirectories []string
 	searchHeading     string
+)
+var (
+	LogLevel = log.WarnLevel
 )
 
 //abstractParagraph represents the paragraph which will be used as abstract.
@@ -42,6 +47,8 @@ type astNode struct {
 
 // Execute orchestrates the execution of the library
 func Execute(output string, rootDirectory string) {
+
+	log.SetLevel(LogLevel)
 
 	// Add Cobra CLI later
 	contentNode, contentByte := buildIndexContent(rootDirectory, ignoreDirectories)
@@ -262,6 +269,7 @@ func buildIndexContent(rootDirectory string, ignoreDirectories []string) (astNod
 
 	for _, file := range files {
 
+		log.Debugf("Reading file: %s", file.path)
 		heading := ast.NewHeading(file.calculatePathDepth())
 
 		paragraph := ast.NewParagraph()


### PR DESCRIPTION
* Adding `--debug` mode to help troubleshoot issues with a few list of Markdowns
* Renaming flag --skipDirectory to --skip since the name was a but confusing